### PR TITLE
Adding Java 11 and Java 13, Java 8 still default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,41 @@ base_java8
 =========
 
 base_java8 is a just another vague acronym that other stuff depends on.
-This is an ansible-role to install Java 8.
+This is an ansible-role to install several Java versions on Centos or Ubuntu.
 
 Requirements
 ------------
 
-RHEL-like , Ubuntu, or Debian.
+Centos 6 or 7. Ubuntu Xenial or Bionic.
 
 
 Role Variables
 --------------
 
-    java8_maj: 8
-    java8_min: 0
-    java8_ser: 111
-    java8_patch: b14
+These lists drive the installation of packages.
+
+```yaml
+
+  java8_packages:
+    - 'java-1.8.0-openjdk-headless.x86_64'
+    - 'java-1.8.0-openjdk-devel.x86_64'
+  java9_packages: []
+  java11_packages:
+    - 'java-11-openjdk-headless.x86_64'
+    - 'java-11-openjdk-devel.x86_64'
+  java_latest_packages:
+    - 'java-latest-openjdk-headless'
+    - 'java-latest-openjdk-devel.x86_64'
+
+```
+To select the default with alternatives on RedHat:
+`base_jdk: 'java-1.8.0'`
+
+```yaml
+  - 'java-1.8.0'
+  - 'java-11'
+  - 'java-13'
+```
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 java8_rpms:
   - 'java-1.8.0-openjdk-headless.x86_64'
   - 'java-1.8.0-openjdk-devel.x86_64'
+  - 'java-11-openjdk-headless.x86_64'
+  - 'java-11-openjdk-devel.x86_64'
+  - 'java-latest-openjdk-headless'
+  - 'java-latest-openjdk-devel.x86_64'
 
 java8_apt: 'openjdk-8-jdk'
 ubuntu_dir: 'java-8-openjdk-amd64'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,10 @@
 ---
+# for alternatives select another base_jdk in playbook vars
+base_jdk: 'java-1.8.0'
+# out of this list
+base_jdk_alternatives:
+  - 'java-1.8.0'
+  - 'java-11'
+  - 'java-13'
 
-java8_rpms:
-  - 'java-1.8.0-openjdk-headless.x86_64'
-  - 'java-1.8.0-openjdk-devel.x86_64'
-  - 'java-11-openjdk-headless.x86_64'
-  - 'java-11-openjdk-devel.x86_64'
-  - 'java-latest-openjdk-headless'
-  - 'java-latest-openjdk-devel.x86_64'
-
-java8_apt: 'openjdk-8-jdk'
 ubuntu_dir: 'java-8-openjdk-amd64'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,9 @@
 java8_top: '/usr/lib/jvm'
 # for alternatives select another base_jdk in playbook vars
 base_jdk: 'java-1.8.0'
+
 # out of this list
 base_jdk_alternatives:
   - 'java-1.8.0'
   - 'java-11'
   - 'java-13'
-
-ubuntu_dir: 'java-8-openjdk-amd64'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+java8_top: '/usr/lib/jvm'
 # for alternatives select another base_jdk in playbook vars
 base_jdk: 'java-1.8.0'
 # out of this list

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,8 +14,11 @@ platforms:
   - name: base-java8-centos6
     image: centos:6
     privileged: true
-  - name: base-java8-ubuntu
+  - name: base-java8-xenial
     image: ubuntu:xenial
+    privileged: True
+  - name: base-java8-bionic
+    image: ubuntu:bionic
     privileged: True
 provisioner:
   name: ansible

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,8 +4,8 @@
   vars:
     base_jdk: 'java-11'
   roles:
-    - {role: dockpack.base_goss}
     - {role: base_java8}
+    - {role: dockpack.base_goss}
 
   post_tasks:
     - include_tasks:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,8 +1,6 @@
 ---
 # Standards: 0.2
 - hosts: all
-  vars:
-    base_jdk: 'java-11'
   roles:
     - {role: base_java8}
     - {role: dockpack.base_goss}

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,9 +1,11 @@
 ---
 # Standards: 0.2
 - hosts: all
+  vars:
+    base_jdk: 'java-11'
   roles:
     - {role: dockpack.base_goss}
-    - {role: base_java8, continue_on_error: False}
+    - {role: base_java8}
 
   post_tasks:
     - include_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,14 @@
 ---
 
-- name: Set java_top
+- name: Make sure java_top exists
   become: yes
-  set_fact:
-    java8_top: '/usr/lib/jvm'
+  file:
+    path: "{{ java8_top }}"
+    state: directory
+    owner: root
+    mode: 0755
   tags:
     - java8
-    - java8_install
-    - java8_profile
-    - java8_test
-    - java8_alternatives
-    - test
-    - config
-    - ant_test
-    - maven_test
-    - gradle_test
-
 
 - name: Ensure python-apt is installed.
   when: ansible_os_family == 'Debian'
@@ -47,6 +40,7 @@
     - java9
     - java11
     - java13
+    - test
 
 - name: Ensure Java8 is installed
   when:
@@ -179,24 +173,15 @@
   retries: 3
   delay: 3
 
-- name: Make sure java_top exists
-  become: yes
-  file:
-    path: "{{ java8_top }}"
-    state: directory
-    owner: root
-    mode: 0755
-  tags:
-    - java8
-
 - name: This is JAVA_HOME
   when: ansible_os_family == 'RedHat'
   set_fact:
-    java8_home: "{{ java8_top }}/java"
+    java8_home: "{{ java8_top }}/{{ base_jdk }}"
   tags:
     - config
     - java8
     - java8_test
+    - java11
     - test
     - ant_test
     - maven_test
@@ -244,6 +229,7 @@
   tags:
     - java8
     - java8_profile
+    - java11
     - test
     - config
 
@@ -254,7 +240,9 @@
     dest: /etc/profile.d/java.sh
   tags:
     - config
+    - test
     - java8
+    - java11
     - java8_profile
 
 - name: ensure directory exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,4 +244,3 @@
     - java8
     - java11
     - java8_profile
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
     - java11
     - java13
     - test
+    - config
 
 - name: Ensure Java8 is installed
   when:
@@ -174,27 +175,13 @@
   delay: 3
 
 - name: This is JAVA_HOME
-  when: ansible_os_family == 'RedHat'
   set_fact:
-    java8_home: "{{ java8_top }}/{{ base_jdk }}"
+    java8_home: "{{ java8_top }}/{{ base_jdk }}{{ javahome_suffix }}"
   tags:
     - config
     - java8
     - java8_test
     - java11
-    - test
-    - ant_test
-    - maven_test
-    - gradle_test
-
-- name: This is JAVA_HOME
-  when: ansible_os_family == 'Debian'
-  set_fact:
-    java8_home: "{{ java8_top }}/{{ ubuntu_dir }}"
-  tags:
-    - config
-    - java8
-    - java8_test
     - test
     - ant_test
     - maven_test
@@ -222,6 +209,19 @@
     - java8
     - config
 
+- name: ensure directory exists
+  file:
+    path: /root
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+  tags:
+    - java8
+    - java8_profile
+    - test
+    - config
+
 - name: Copy test_java.yml to remote
   template:
     src: test_java.yml.j2
@@ -245,15 +245,3 @@
     - java11
     - java8_profile
 
-- name: ensure directory exists
-  file:
-    path: /root
-    state: directory
-    owner: root
-    group: root
-    mode: 0700
-  tags:
-    - java8
-    - java8_profile
-    - test
-    - config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,35 +16,6 @@
     - maven_test
     - gradle_test
 
-- name: What java8_rpms
-  when: ansible_os_family == 'RedHat'
-  debug:
-    msg: "{{ java8_rpms }}"
-
-- name: Ensure Java is installed.
-  when: ansible_os_family == 'RedHat'
-  yum:
-    name: "{{ java8_rpms }}"
-    state: present
-  register: network_access
-  until: network_access is success
-  retries: 10
-  delay: 2
-
-- name: Ensure file is installed for tests
-  when: ansible_os_family == 'RedHat'
-  yum:
-    name: file
-    state: present
-  register: network_access
-  until: network_access is success
-  retries: 10
-  delay: 2
-
-- name: What java8_apt
-  when: ansible_os_family == 'Debian'
-  debug:
-    msg: "{{ java8_apt }}"
 
 - name: Ensure python-apt is installed.
   when: ansible_os_family == 'Debian'
@@ -53,8 +24,8 @@
     state: present
   register: network_access
   until: network_access is success
-  retries: 10
-  delay: 2
+  retries: 3
+  delay: 3
 
 - name: Update apt cache.
   when: ansible_os_family == 'Debian'
@@ -63,21 +34,150 @@
     cache_valid_time: 86400
   register: network_access
   until: network_access is success
-  retries: 10
-  delay: 2
+  retries: 3
+  delay: 3
   tags:
     - java8
     - java8_install
 
-- name: Ensure Java is installed.
-  when: ansible_os_family == 'Debian'
-  apt:
-    name: "{{ java8_apt }}"
+- name: Which java packages to install
+  include_vars: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
+  tags:
+    - java8
+    - java9
+    - java11
+    - java13
+
+- name: Ensure Java8 is installed
+  when:
+    - java8_packages is defined
+    - java8_packages|length
+  package:
+    name: "{{ java8_packages }}"
     state: present
   register: network_access
   until: network_access is success
-  retries: 10
-  delay: 2
+  retries: 3
+  delay: 3
+  tags:
+    - java8
+
+- name: Ensure Java9 is installed
+  when:
+    - java9_packages is defined
+    - java9_packages|length
+  package:
+    name: "{{ java9_packages }}"
+    state: present
+  register: network_access
+  until: network_access is success
+  retries: 3
+  delay: 3
+  tags:
+    - java9
+
+- name: Ensure Java11 is installed
+  when:
+    - java11_packages is defined
+    - java11_packages|length
+  package:
+    name: "{{ java11_packages }}"
+    state: present
+  register: network_access
+  until: network_access is success
+  retries: 3
+  delay: 3
+  tags:
+    - java11
+
+- name: Ensure epel-release is installed
+  when:
+    - java_latest_packages is defined
+    - java_latest_packages|length
+  yum:
+    name: epel-release
+    state: present
+  register: network_access
+  until: network_access is success
+  retries: 3
+  delay: 3
+  tags:
+    - java13
+
+- name: Ensure Java-latest is installed
+  when:
+    - java_latest_packages is defined
+    - java_latest_packages|length
+  package:
+    name: "{{ java_latest_packages }}"
+    state: present
+  register: network_access
+  until: network_access is success
+  retries: 3
+  delay: 3
+  tags:
+    - java13
+
+- name: Correct java alternatives selected
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version|int >= 7
+  alternatives:
+    link: "/usr/bin/{{ item }}"
+    name: "{{ item }}"
+    path: "/usr/lib/jvm/{{ base_jdk }}/bin/{{ item }}"
+  with_items:
+    - java
+    - javac
+  tags:
+    - alternatives
+    - java11
+
+- name: Correct tools alternatives selected
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version|int >= 7
+  alternatives:
+    link: "/etc/alternatives/{{ item }}"
+    name: "{{ item }}"
+    path: "/usr/lib/jvm/{{ base_jdk }}/bin/{{ item }}"
+  with_items:
+    - jar
+    - jarsigner
+    - javadoc
+    - javap
+    - jcmd
+    - jconsole
+    - jdb
+    - jdeps
+    - jinfo
+    - jjs
+    - jmap
+    - jps
+    - jrunscript
+    - jstack
+    - jstat
+    - jstatd
+    - keytool
+    - pack200
+    - rmic
+    - rmid
+    - rmiregistry
+    - serialver
+    - unpack200
+  tags:
+    - alternatives
+    - java11
+
+- name: Ensure file is installed for tests
+  when: ansible_os_family == 'RedHat'
+  yum:
+    name: file
+    state: present
+  register: network_access
+  until: network_access is success
+  retries: 3
+  delay: 3
 
 - name: Make sure java_top exists
   become: yes

--- a/templates/test_java.yml.j2
+++ b/templates/test_java.yml.j2
@@ -1,27 +1,15 @@
 file:
-  "{{ java8_home }}/bin/javac":
+  "/usr/lib/jvm/{{ base_jdk }}/bin/javac":
     exists: true
     owner: root
     group: root
     filetype: file
     contains: []
-  "{{ java8_home }}/bin/java":
+  "/usr/lib/jvm/{{ base_jdk }}/bin/java":
     exists: true
     owner: root
     group: root
     contains: []
-  "{{ java8_home }}/jre/bin/java":
-    exists: true
-    owner: root
-    group: root
-    filetype: file
-    contains: []
-  "{{ java8_home }}/jre/lib/security/java.security":
-    exists: true
-    owner: root
-    group: root
-    contains:
-      - 'crypto.policy=unlimited'
 
 package:
 {% if ansible_os_family == 'RedHat' %}

--- a/templates/test_java.yml.j2
+++ b/templates/test_java.yml.j2
@@ -1,11 +1,11 @@
 file:
-  "/usr/lib/jvm/{{ base_jdk }}/bin/javac":
+  "{{ java8_home }}/bin/javac":
     exists: true
     owner: root
     group: root
     filetype: file
     contains: []
-  "/usr/lib/jvm/{{ base_jdk }}/bin/java":
+  "{{ java8_home }}/bin/java":
     exists: true
     owner: root
     group: root

--- a/templates/test_java.yml.j2
+++ b/templates/test_java.yml.j2
@@ -25,11 +25,8 @@ file:
 
 package:
 {% if ansible_os_family == 'RedHat' %}
-{% for item in java8_rpms %}
+{% for item in java8_packages %}
   {{ item }}:
     installed: true
 {% endfor %}
-{% else %}
-  {{ java8_apt }}:
-    installed: true
 {% endif %}

--- a/vars/Debian16.yml
+++ b/vars/Debian16.yml
@@ -7,3 +7,4 @@ java9_packages:
   - 'openjdk-9-jre-headless'
 java11_packages: []
 java_latest_packages: []
+javahome_suffix: '-openjdk-amd64'

--- a/vars/Debian16.yml
+++ b/vars/Debian16.yml
@@ -1,0 +1,9 @@
+---
+
+java8_packages:
+  - 'openjdk-8-jdk'
+java9_packages:
+  - 'openjdk-9-jdk-headless'
+  - 'openjdk-9-jre-headless'
+java11_packages: []
+java_latest_packages: []

--- a/vars/Debian18.yml
+++ b/vars/Debian18.yml
@@ -1,0 +1,9 @@
+---
+
+java8_packages:
+  - 'openjdk-8-jdk'
+java9_packages: []
+java11_packages:
+  - 'openjdk-11-jdk-headless'
+  - 'openjdk-11-jre-headless'
+java_latest_packages: []

--- a/vars/Debian18.yml
+++ b/vars/Debian18.yml
@@ -7,3 +7,4 @@ java11_packages:
   - 'openjdk-11-jdk-headless'
   - 'openjdk-11-jre-headless'
 java_latest_packages: []
+javahome_suffix: '-openjdk-amd64'

--- a/vars/RedHat6.yml
+++ b/vars/RedHat6.yml
@@ -1,5 +1,6 @@
 ---
-
+java8_top: '/usr/lib/jvm'
 java8_packages:
   - 'java-1.8.0-openjdk-headless.x86_64'
   - 'java-1.8.0-openjdk-devel.x86_64'
+javahome_suffix: ''

--- a/vars/RedHat6.yml
+++ b/vars/RedHat6.yml
@@ -1,0 +1,5 @@
+---
+
+java8_packages:
+  - 'java-1.8.0-openjdk-headless.x86_64'
+  - 'java-1.8.0-openjdk-devel.x86_64'

--- a/vars/RedHat7.yml
+++ b/vars/RedHat7.yml
@@ -1,5 +1,5 @@
 ---
-
+java8_top: '/usr/lib/jvm'
 java8_packages:
   - 'java-1.8.0-openjdk-headless.x86_64'
   - 'java-1.8.0-openjdk-devel.x86_64'
@@ -10,3 +10,4 @@ java11_packages:
 java_latest_packages:
   - 'java-latest-openjdk-headless'
   - 'java-latest-openjdk-devel.x86_64'
+javahome_suffix: ''

--- a/vars/RedHat7.yml
+++ b/vars/RedHat7.yml
@@ -1,0 +1,12 @@
+---
+
+java8_packages:
+  - 'java-1.8.0-openjdk-headless.x86_64'
+  - 'java-1.8.0-openjdk-devel.x86_64'
+java9_packages: []
+java11_packages:
+  - 'java-11-openjdk-headless.x86_64'
+  - 'java-11-openjdk-devel.x86_64'
+java_latest_packages:
+  - 'java-latest-openjdk-headless'
+  - 'java-latest-openjdk-devel.x86_64'


### PR DESCRIPTION
**sets JAVA_HOME to one of these:**  
- /usr/lib/jvm/java-1.8.0
- /usr/lib/jvm/java-11
- /usr/lib/jvm/java-13


Selects the default with alternatives on RedHat:
`base_jdk: 'java-1.8.0'`

```yaml
  - 'java-1.8.0'
  - 'java-11'
  - 'java-13'
```