### PR TITLE
ansible-later

### DIFF
--- a/.later.yml
+++ b/.later.yml
@@ -1,0 +1,17 @@
+---
+ansible:
+  # Add the name of used custom Ansible modules. Otherwise ansible-later
+  # can't detect unknown modules and will through an error.
+  # Modules which are bundled with the role and placed in a './library'
+  # directory will be auto-detected and don't need to be added to this list.
+  custom_modules: []
+
+  # List of yamllint compatible literal bools (ANSIBLE0014)
+  literal-bools:
+    - "true"
+    - "false"
+rules:
+  exclude_files:
+    - molecule/
+    - requirements.txt
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ base_jdk_alternatives:
   - 'java-1.8.0'
   - 'java-11'
   - 'java-13'
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-
+# Standards: 0.2
 galaxy_info:
   role_name: base_java8
   namespace: dockpack
@@ -27,3 +27,4 @@ galaxy_info:
     - development
 
 dependencies: []
+...

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,7 +1,6 @@
 ---
 
 - name: Make sure java_top exists
-  become: true
   file:
     path: "{{ java8_top }}"
     state: directory
@@ -212,7 +211,7 @@
     - java8
     - config
 
-- name: ensure directory exists
+- name: Ensure directory exists
   file:
     path: /root
     state: directory
@@ -238,7 +237,6 @@
     - config
 
 - name: Fix JAVA_HOME
-  become: true
   template:
     src: java.sh
     dest: /etc/profile.d/java.sh
@@ -249,3 +247,4 @@
     - java8
     - java11
     - java8_profile
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,3 +13,4 @@
   when: ansible_os_family == 'Windows'
   tags:
     - windows
+...

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -28,3 +28,4 @@
   win_path:
     elements:
       - "{{ win_java_path }}"
+...

--- a/vars/Debian16.yml
+++ b/vars/Debian16.yml
@@ -8,3 +8,4 @@ java9_packages:
 java11_packages: []
 java_latest_packages: []
 javahome_suffix: '-openjdk-amd64'
+...

--- a/vars/Debian18.yml
+++ b/vars/Debian18.yml
@@ -8,3 +8,4 @@ java11_packages:
   - 'openjdk-11-jre-headless'
 java_latest_packages: []
 javahome_suffix: '-openjdk-amd64'
+...

--- a/vars/RedHat6.yml
+++ b/vars/RedHat6.yml
@@ -1,6 +1,8 @@
 ---
+
 java8_top: '/usr/lib/jvm'
 java8_packages:
   - 'java-1.8.0-openjdk-headless.x86_64'
   - 'java-1.8.0-openjdk-devel.x86_64'
 javahome_suffix: ''
+...

--- a/vars/RedHat7.yml
+++ b/vars/RedHat7.yml
@@ -1,4 +1,5 @@
 ---
+
 java8_top: '/usr/lib/jvm'
 java8_packages:
   - 'java-1.8.0-openjdk-headless.x86_64'
@@ -11,3 +12,4 @@ java_latest_packages:
   - 'java-latest-openjdk-headless'
   - 'java-latest-openjdk-devel.x86_64'
 javahome_suffix: ''
+...

--- a/vars/RedHat8.yml
+++ b/vars/RedHat8.yml
@@ -1,4 +1,5 @@
 ---
+
 java8_top: '/usr/lib/jvm'
 java8_packages:
   - 'java-1.8.0-openjdk-headless.x86_64'
@@ -9,3 +10,4 @@ java11_packages:
   - 'java-11-openjdk-devel.x86_64'
 java_latest_packages: []
 javahome_suffix: ''
+...

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,4 +1,5 @@
 ---
+
 jdk_package: jdk8
 java_major_version: 8.0
 java_minor_version: 211
@@ -9,3 +10,4 @@ java_minor: "{{ java_minor_version }}"
 
 win_java_home: "{{ win_programs }}jdk1.{{ java_major }}_{{ java_minor }}"
 win_java_path: "{{ win_programs }}jdk{{ java_major }}_{{ java_minor }}\bin"
+...


### PR DESCRIPTION
ansible-later is a best practice scanner and linting tool. In most cases, if you write Ansible roles in a team, it helps to have a coding or best practice guideline in place. This will make Ansible roles more readable for all maintainers and can reduce the troubleshooting time. While ansible-later aims to be a fast and easy to use linting tool for your Ansible resources, it might not be that feature completed as required in some situations. If you need a more in-depth analysis you can take a look at ansible-lint.

ansible-later does not ensure that your role will work as expected. For deployment tests you can use other tools like molecule.

You can find the full documentation at https://ansible-later.geekdocs.de.